### PR TITLE
Fixed crash caused by GetOwningPawn() returning null.

### DIFF
--- a/StarryExpanse/Base/GUI/SEHUD.cpp
+++ b/StarryExpanse/Base/GUI/SEHUD.cpp
@@ -23,8 +23,6 @@ void ASEHUD::DrawHUD()
       // Find center of the Canvas
       const FVector2D Center(Canvas->ClipX * 0.5f, Canvas->ClipY * 0.5f);
 
-      auto Character = CastChecked<ASECharacter>(GetOwningPawn());
-      auto aspect = Character->GetCameraComponent()->AspectRatio;
       auto MousePosition = FVector2D::ZeroVector;
       if (!GetOwningPlayerController()->GetMousePosition(MousePosition.X, MousePosition.Y))
          MousePosition = Center;


### PR DESCRIPTION
Was crashing when typecasting to char. This was only used to determine
the aspect ratio - which was unused, so simply deleted it.